### PR TITLE
Improvements to test actions including gate level tests

### DIFF
--- a/.github/workflows/gds.yaml
+++ b/.github/workflows/gds.yaml
@@ -68,13 +68,15 @@ jobs:
       run: ./tt/tt_tool.py --print-cell-category >> $GITHUB_STEP_SUMMARY
 
     - name: populate src cache
-      uses: actions/cache@v3
+      if: success() || failure()
+      uses: actions/cache/save@v3
       with:
         path: src
         key: ${{ runner.os }}-src-${{ github.run_id }}
 
     - name: populate runs cache
-      uses: actions/cache@v3
+      if: success() || failure()
+      uses: actions/cache/save@v3
       with:
         path: runs
         key: ${{ runner.os }}-runs-${{ github.run_id }}
@@ -130,21 +132,23 @@ jobs:
   artifact:
     needs:
     - gds
+    if: success() || failure()
     runs-on: ubuntu-latest
     steps:
     - name: restore src cache
-      uses: actions/cache@v3
+      uses: actions/cache/restore@v3
       with:
         path: src
         key: ${{ runner.os }}-src-${{ github.run_id }}
 
     - name: restore runs cache
-      uses: actions/cache@v3
+      uses: actions/cache/restore@v3
       with:
         path: runs
         key: ${{ runner.os }}-runs-${{ github.run_id }}
 
     - name: upload artifact
+      if: ${{ needs.gds.result == 'success' }}
       uses: actions/upload-artifact@v3
       with:
           # path depends on the tag and the module name
@@ -154,6 +158,16 @@ jobs:
             runs/wokwi/results/final/*
             runs/wokwi/reports/metrics.csv
             runs/wokwi/reports/synthesis/1-synthesis.AREA 0.stat.rpt
+
+    - name: upload failure report
+      if: ${{ needs.gds.result == 'failure' }}
+      uses: actions/upload-artifact@v3
+      with:
+          # path depends on the tag and the module name
+          name: GDS-reports
+          path: |
+            src/*
+            runs/wokwi/reports/*
 
 ##############################################################
 # Run gate level tests

--- a/.github/workflows/gds.yaml
+++ b/.github/workflows/gds.yaml
@@ -156,6 +156,68 @@ jobs:
             runs/wokwi/reports/synthesis/1-synthesis.AREA 0.stat.rpt
 
 ##############################################################
+# Run gate level tests
+
+  gltest:
+    needs:
+    - gds
+    env:
+        OPENLANE_TAG:           2023.02.14
+        OPENLANE_IMAGE_NAME:    efabless/openlane:4cd0986b3ae550cdf7a6d0fba4e0657012f635d8-amd64
+        OPENLANE_ROOT:          /home/runner/openlane
+        PDK_ROOT:               /home/runner/pdk
+        PDK:                    sky130B
+
+    # ubuntu
+    runs-on: ubuntu-latest
+    steps:
+    # need the repo checked out
+    - name: checkout repo
+      uses: actions/checkout@v3
+      with:
+          submodules: recursive
+
+    # build PDK
+    - name: pdk
+      run: |
+        cd $HOME
+        git clone https://github.com/efabless/caravel_user_project.git
+        cd caravel_user_project
+        make install pdk-with-volare
+
+    # install oss fpga tools
+    - name: install oss-cad-suite
+      uses: YosysHQ/setup-oss-cad-suite@v2
+      with:
+          python-override: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+    - run: | 
+        yosys --version
+        iverilog -V
+        cocotb-config --libpython
+        cocotb-config --python-bin
+
+    - name: restore runs cache
+      uses: actions/cache@v3
+      with:
+        path: runs
+        key: ${{ runner.os }}-runs-${{ github.run_id }}
+
+    - name: test
+      run: |
+        cd src
+        make clean
+        GATES=yes make
+        # make will return success even if the test fails, so check for failure in the results.xml
+        ! grep failure results.xml
+
+    - name: upload vcd
+      uses: actions/upload-artifact@v3
+      with:
+          name: gatelevel-test-vcd
+          path: src/tb.vcd
+
+##############################################################
 # Publish to pages to get a nicely formatted result
 
   pages:

--- a/.github/workflows/gds.yaml
+++ b/.github/workflows/gds.yaml
@@ -212,6 +212,7 @@ jobs:
         ! grep failure results.xml
 
     - name: upload vcd
+      if: success() || failure()
       uses: actions/upload-artifact@v3
       with:
           name: gatelevel-test-vcd

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,3 +30,8 @@ jobs:
         # make will return success even if the test fails, so check for failure in the results.xml
         ! grep failure results.xml
 
+    - name: upload vcd
+      uses: actions/upload-artifact@v3
+      with:
+          name: test-vcd
+          path: src/tb.vcd

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,6 +31,7 @@ jobs:
         ! grep failure results.xml
 
     - name: upload vcd
+      if: success() || failure()
       uses: actions/upload-artifact@v3
       with:
           name: test-vcd

--- a/src/Makefile
+++ b/src/Makefile
@@ -5,7 +5,24 @@
 SIM ?= icarus
 TOPLEVEL_LANG ?= verilog
 
+ifneq ($(GATES),yes)
+# normal simulation
 VERILOG_SOURCES += $(PWD)/tb.v $(PWD)/counter.v $(PWD)/decoder.v
+else
+# pick up the gatelevel verilog from /runs/wokwi/results/final/verilog/gl/
+GATE_SOURCES := $(filter-out $(wildcard $(PWD)/../runs/wokwi/results/final/verilog/gl/*.nl.v), $(wildcard $(PWD)/../runs/wokwi/results/final/verilog/gl/*.v))
+VERILOG_SOURCES := $(PWD)/tb.v $(GATE_SOURCES)
+
+# gate level simulation requires some extra setup
+COMPILE_ARGS    += -DGL_TEST
+COMPILE_ARGS    += -DFUNCTIONAL
+COMPILE_ARGS    += -DUSE_POWER_PINS
+COMPILE_ARGS    += -DSIM
+COMPILE_ARGS    += -DUNIT_DELAY=#1
+COMPILE_ARGS    += -DSIM
+VERILOG_SOURCES += $(PDK_ROOT)/sky130B/libs.ref/sky130_fd_sc_hd/verilog/primitives.v
+VERILOG_SOURCES += $(PDK_ROOT)/sky130B/libs.ref/sky130_fd_sc_hd/verilog/sky130_fd_sc_hd.v
+endif
 
 # TOPLEVEL is the name of the toplevel module in your Verilog or VHDL file
 TOPLEVEL = tb

--- a/src/tb.v
+++ b/src/tb.v
@@ -27,6 +27,11 @@ module tb (
 
     // instantiate the DUT
     seven_segment_seconds seven_segment_seconds(
+`ifdef GL_TEST
+        // for gatelevel testing we need to set up the power pins
+        .vccd1(1'b1),
+        .vssd1(1'b0),
+`endif
         .io_in  (inputs),
         .io_out (outputs)
         );


### PR DESCRIPTION
This change runs the gate level tests as part of the GDS action, to avoid having to commit files.

I also save VCD files as test artifacts for inspection from both the gate level and normal test jobs.